### PR TITLE
feat: Token 검증을 위한 AuthorizationArgumentResolver 추가 

### DIFF
--- a/src/main/java/com/official/memento/global/annotation/Authorization.java
+++ b/src/main/java/com/official/memento/global/annotation/Authorization.java
@@ -1,0 +1,11 @@
+package com.official.memento.global.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Authorization {
+}

--- a/src/main/java/com/official/memento/global/annotation/AuthorizationUser.java
+++ b/src/main/java/com/official/memento/global/annotation/AuthorizationUser.java
@@ -1,0 +1,6 @@
+package com.official.memento.global.annotation;
+
+public record AuthorizationUser(
+        Long memberId
+) {
+}

--- a/src/main/java/com/official/memento/global/resolver/AuthArgumentResolver.java
+++ b/src/main/java/com/official/memento/global/resolver/AuthArgumentResolver.java
@@ -1,0 +1,46 @@
+package com.official.memento.global.resolver;
+
+import com.official.memento.global.annotation.AuthorizationUser;
+import com.official.memento.global.annotation.Authorization;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+public class AuthArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private static final String AUTHORIZATION_HEADER_PREFIX = "Bearer ";
+    private static final String EMPTY = "";
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(Authorization.class);
+    }
+
+    @Override
+    public AuthorizationUser resolveArgument(MethodParameter parameter,
+                                             ModelAndViewContainer mavContainer,
+                                             NativeWebRequest webRequest,
+                                             WebDataBinderFactory binderFactory) throws Exception {
+        HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
+        String authorizationHeaderValue = request.getHeader(HttpHeaders.AUTHORIZATION);
+        String token = parseToken(authorizationHeaderValue);
+        // TODO : Token 검증 로직 추가
+        return new AuthorizationUser(validateToken(token));
+    }
+
+    private Long validateToken(String token) {
+        return 1L;
+    }
+
+    private String parseToken(String token) {
+        // TODO : null check and throw AuthException
+        assert token != null;
+        return token.replace(AUTHORIZATION_HEADER_PREFIX, EMPTY);
+    }
+}


### PR DESCRIPTION
## ✨ Related Issue
- close #8 

## 📝 기능 구현 명세
- 이후에 소셜로그인이 구현되면, token을 검증하고 api에 넘겨줄 수 있는 ArgumentResolver를 구현했습니다.
- 수정이 필요한 부분은 TODO 주석을 달아놨습니다.

## 🐥 추가적인 언급 사항
- 소셜로그인 구현하면서 구체적인 Token 검증 로직은 구현이 필요할 것 같아요.
- 다음 issue에서 기본적인 인증 도메인 설계는 필요할 것 같아요.