### PR TITLE
fix: Swagger 설정 수정

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ springBoot = "3.4.1"
 springDependencyManagement = "1.1.7"
 ktlint = "12.1.0"
 coroutines = "1.7.3"
-springdoc = "2.6.0"
+springdoc = "2.7.0"
 jjwt = "0.11.5"
 
 [libraries]
@@ -16,6 +16,7 @@ kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-cor
 kotlinx-coroutines-reactor = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-reactor", version.ref = "coroutines" }
 spring-boot-starter-data-jpa = { group = "org.springframework.boot", name = "spring-boot-starter-data-jpa" }
 springdoc-openapi-starter-webmvc-ui = { group = "org.springdoc", name = "springdoc-openapi-starter-webmvc-ui", version.ref = "springdoc" }
+springdoc-openapi-starter-webmvc-api = { group = "org.springdoc", name = "springdoc-openapi-starter-webmvc-api", version.ref = "springdoc" }
 postgresql = { group = "org.postgresql", name = "postgresql" }
 
 # JWT

--- a/src/main/java/com/official/memento/global/config/SwaggerConfig.java
+++ b/src/main/java/com/official/memento/global/config/SwaggerConfig.java
@@ -1,0 +1,31 @@
+package com.official.memento.global.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+
+@Configuration
+@Profile("!prod")
+class SwaggerConfig {
+
+    private static final String DESCRIPTION = """   
+        401 에러가 발생할 경우, 토큰이 만료되었거나, 잘못된 토큰일 수 있습니다. -> 토큰을 재발급 받아주세요.
+        그럼에도 동작하지 않는 경우, -> 서버에게 문의해주세요.
+    
+        500 에러가 발생할 경우, 서버에 문제가 있을 수 있습니다. -> 서버에게 문의해주세요.
+        """;
+
+    @Bean
+    OpenAPI openAPI() {
+        return new OpenAPI()
+                .info(
+                        new Info()
+                                .title("Memento API Docs")
+                                .description(DESCRIPTION)
+                                .version("1.0.0")
+                );
+    }
+}


### PR DESCRIPTION
## ✨ Related Issue
- close #48 
  <br/>

## 📝 기능 구현 명세
- Swagger 문서가 나오지 않는 문제를 수정했습니다.
- Swagger 설정을 Bean으로 등록하고, prod에서는 조회할 수없게 함.
- 의존성 추가 및 버전을 수정했습니다.

## 🐥 추가적인 언급 사항
여기 참고 했어요 . https://github.com/springdoc/springdoc-openapi/issues/2813
