### PR TITLE
Feat/#62 token 갱신 api

### DIFF
--- a/src/main/java/com/official/memento/auth/controller/AuthApiController.java
+++ b/src/main/java/com/official/memento/auth/controller/AuthApiController.java
@@ -7,10 +7,14 @@ import com.official.memento.auth.service.AuthResult;
 import com.official.memento.auth.service.AuthService;
 import com.official.memento.auth.service.command.AuthCommand;
 import com.official.memento.global.dto.SuccessResponse;
+import com.official.memento.global.exception.ErrorCode;
+import com.official.memento.global.exception.MementoException;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
 
 import jakarta.validation.Valid;
@@ -30,11 +34,31 @@ public class AuthApiController {
         final AuthResult authResult = authService.authenticate(command);
 
         final AuthApiResponse response = new AuthApiResponse(
-                "소셜 로그인 성공",
                 authResult.getAccessToken().getToken(),
                 authResult.getRefreshToken().getToken(),
                 authResult.isNewUser()
         );
         return SuccessResponse.of(HttpStatus.OK, "소셜 로그인 성공", response);
+    }
+
+    @PostMapping("/api/v1/auth/token/refresh")
+    public ResponseEntity<SuccessResponse<AuthApiResponse>> refreshTokens(
+            @RequestHeader(HttpHeaders.AUTHORIZATION) String authorizationHeader) {
+        String refreshToken = parseToken(authorizationHeader);
+        AuthResult authResult = authService.refreshTokens(refreshToken);
+
+        AuthApiResponse response = new AuthApiResponse(
+                authResult.getAccessToken().getToken(),
+                authResult.getRefreshToken().getToken(),
+                false
+        );
+        return SuccessResponse.of(HttpStatus.OK, "토큰 갱신 성공", response);
+    }
+
+    private String parseToken(String authorizationHeader) {
+        if (authorizationHeader == null || !authorizationHeader.startsWith("Bearer ")) {
+            throw new MementoException(ErrorCode.INVALID_REFRESH_TOKEN);
+        }
+        return authorizationHeader.substring(7);
     }
 }

--- a/src/main/java/com/official/memento/auth/controller/dto/AuthApiResponse.java
+++ b/src/main/java/com/official/memento/auth/controller/dto/AuthApiResponse.java
@@ -1,7 +1,6 @@
 package com.official.memento.auth.controller.dto;
 
 public record AuthApiResponse(
-        String message, // 로그인 성공 메시지
         String accessToken, // 발급된 Access Token
         String refreshToken, // 발급된 Refresh Token
         boolean isNewUser // 신규 사용자 여부

--- a/src/main/java/com/official/memento/auth/domain/port/AuthRepository.java
+++ b/src/main/java/com/official/memento/auth/domain/port/AuthRepository.java
@@ -7,4 +7,5 @@ import java.util.Optional;
 public interface AuthRepository {
     MemberAuth save(MemberAuth auth);
     Optional<MemberAuth> findByPlatformIdAndProvider(String platformId, AuthProvider provider);
+    Optional<MemberAuth> findByMemberId(Long memberId);
 }

--- a/src/main/java/com/official/memento/auth/infrastructure/AuthRepositoryAdapter.java
+++ b/src/main/java/com/official/memento/auth/infrastructure/AuthRepositoryAdapter.java
@@ -48,4 +48,16 @@ public class AuthRepositoryAdapter implements AuthRepository {
                         entity.getRefreshToken()
                 ));
     }
+
+    @Override
+    public Optional<MemberAuth> findByMemberId(final Long memberId) {
+        return memberAuthJpaRepository.findByMemberId(memberId)
+                .map(entity -> MemberAuth.withId(
+                        entity.getId(),
+                        entity.getMemberId(),
+                        entity.getProvider(),
+                        entity.getPlatformId(),
+                        entity.getRefreshToken()
+                ));
+    }
 }

--- a/src/main/java/com/official/memento/auth/service/AuthService.java
+++ b/src/main/java/com/official/memento/auth/service/AuthService.java
@@ -54,10 +54,10 @@ public class AuthService implements AuthUseCase {
         MemberAuth auth = authRepository.findByPlatformIdAndProvider(platformId, provider)
                 .orElseGet(() -> createNewMember(platformId, provider));
 
-        boolean isNewUser = memberRepository.findPersonalInfoByMemberId(auth.getId()).isEmpty();
+        boolean isNewUser = memberRepository.findPersonalInfoByMemberId(auth.getMemberId()).isEmpty();
 
         AccessToken accessToken = jwtUtil.generateAccessToken(String.valueOf(auth.getMemberId()));
-        RefreshToken refreshToken = jwtUtil.generateRefreshToken(String.valueOf(auth.getId().toString()));
+        RefreshToken refreshToken = jwtUtil.generateRefreshToken(String.valueOf(auth.getMemberId()));
 
         auth.withUpdatedToken(refreshToken.getToken());
         authRepository.save(auth);
@@ -71,7 +71,7 @@ public class AuthService implements AuthUseCase {
         return new AuthResult(accessToken, refreshToken, member, isNewUser);
     }
 
-
+    @Transactional
     private MemberAuth createNewMember(String platformId, AuthProvider provider) {
         Member newMember = memberRepository.save(Member.createNew());
         MemberAuth newAuth = MemberAuth.of(newMember.getId(), provider, platformId, "");
@@ -80,6 +80,7 @@ public class AuthService implements AuthUseCase {
         return authRepository.save(newAuth);
     }
 
+    @Transactional
     private AuthProvider getAuthProvider(final String providerName) {
         try {
             return AuthProvider.valueOf(providerName.toUpperCase());
@@ -88,6 +89,7 @@ public class AuthService implements AuthUseCase {
         }
     }
 
+    @Transactional
     private Map<String, Object> verifyIdToken(final AuthProvider provider, final String idToken) {
         final AuthClientOutputPort clientAdapter = authClientAdapters.get(provider);
         if (clientAdapter == null) {
@@ -98,6 +100,27 @@ public class AuthService implements AuthUseCase {
         } catch (Exception e) {
             throw new MementoException(ErrorCode.INVALID_ID_TOKEN);
         }
+    }
+
+    @Transactional
+    public AuthResult refreshTokens(String refreshToken) {
+        if (!jwtUtil.validateToken(refreshToken)) {
+            throw new MementoException(ErrorCode.INVALID_REFRESH_TOKEN);
+        }
+        String memberId = jwtUtil.getUserIdFromToken(refreshToken);
+        MemberAuth memberAuth = authRepository.findByMemberId(Long.parseLong(memberId))
+                .orElseThrow(() -> new MementoException(ErrorCode.INVALID_REFRESH_TOKEN));
+        if (!memberAuth.getRefreshToken().equals(refreshToken)) {
+            throw new MementoException(ErrorCode.INVALID_REFRESH_TOKEN);
+        }
+        AccessToken newAccessToken = jwtUtil.generateAccessToken(memberId);
+        RefreshToken newRefreshToken = jwtUtil.generateRefreshToken(memberId);
+
+        memberAuth.withUpdatedToken(newRefreshToken.getToken());
+        authRepository.save(memberAuth);
+
+        return new AuthResult(newAccessToken, newRefreshToken, null, false);
+
     }
 }
 

--- a/src/main/java/com/official/memento/global/annotation/Authorization.java
+++ b/src/main/java/com/official/memento/global/annotation/Authorization.java
@@ -5,7 +5,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-@Target({ElementType.PARAMETER})
+@Target({ElementType.PARAMETER, ElementType.TYPE_PARAMETER})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface Authorization {
 }

--- a/src/main/java/com/official/memento/global/exception/ErrorCode.java
+++ b/src/main/java/com/official/memento/global/exception/ErrorCode.java
@@ -14,7 +14,8 @@ public enum ErrorCode {
     /* 소셜 로그인 관련 에러 */
     INVALID_ID_TOKEN("유효하지 않은 ID 토큰입니다."),
     UNSUPPORTED_PROVIDER("지원하지 않는 소셜 로그인 제공자입니다."),
-    INVALID_ACCESS_TOKEN("유효하지 않은 액세스 토큰입니다.");
+    INVALID_ACCESS_TOKEN("유효하지 않은 액세스 토큰입니다."),
+    INVALID_REFRESH_TOKEN("유효하지 않은 리프레시 토큰입니다.");
 
     private final String message;
 

--- a/src/main/java/com/official/memento/member/infrastructure/persistence/MemberAuthJpaRepository.java
+++ b/src/main/java/com/official/memento/member/infrastructure/persistence/MemberAuthJpaRepository.java
@@ -7,4 +7,5 @@ import java.util.Optional;
 
 public interface MemberAuthJpaRepository extends JpaRepository<MemberAuthEntity, Long> {
     Optional<MemberAuthEntity> findByPlatformIdAndProvider(String platformId, AuthProvider provider);
+    Optional<MemberAuthEntity> findByMemberId(Long memberId);
 }


### PR DESCRIPTION
## ✨ Related Issue
- close #62 
  <br/>

## 📝 기능 구현 명세
![image](https://github.com/user-attachments/assets/51be5ca3-419c-43fc-b134-f8472632ca99)
클라이언트한테 refresh token을 헤더에 받아서, access token이랑 refresh token 새로 발급 후 DB에 새로운 refresh token을 저장하는 토큰 갱신 API 구현했습니다

## 🐥 추가적인 언급 사항
